### PR TITLE
test against alpine shell

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,7 +11,6 @@ steps:
 - name: test-sisyphus-alpine
   image: alpine
   commands:
-  - apk update && apk add bash
   - ./sisyphus
   - ./sisyphus -k write
   depends_on: [test-shellcheck]


### PR DESCRIPTION
test against the /bin/sh in alpine, instead of depending on installing bash.